### PR TITLE
Add frontend deployment tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.log
 template.packaged.yaml
 coverage
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,48 @@
 language: node_js
 
 node_js:
-  - '8.10'
+- '8.10'
 
 cache:
   directories:
-    - api/node_modules
-    - frontend/node_modules
+  - api/node_modules
+  - frontend/node_modules
 
 env:
   matrix:
-    - DIR=./frontend
-    - DIR=./api
+  - DIR=./frontend
+  - DIR=./api
+  global:
+    - AWS_DEFAULT_REGION='us-west-2'
+    - secure: iOr55D9pAOEepUUWb14ovsDP1jjCnwkZPSKpFRouAvNt//YjbIKVvn8pgjFP1edmQ3oBEIk8jm50L03fxaVPDrFxAZbIfvnNo7mfiwH2fbSDmto6dsCsUtplaw9/dY7lrTeORLLuSpkIGxuLcTuLsli/oxBh+I5UZzYFS71AQEvTLIyOrqIAoDnsdNFMdbmk/8JBtwQBEpM6DBGihRQ4ozMzWRZb9peP2E5qhaCkjVP5BDb8AYclFLp1zEqezYT952JkIZK7uDMspEP4qjK1f4F9MVAzaRPxSVJr7X7Jb2IF6FWuIe0P3bf6Pm1oOMZABdhJ9D38y6BAlJf0XqY7S2Hh5DngVnHrHyF8Zq9sbg9ZYaqvxQGVEI5F8RyPJHHvC47n1hEA80UNiGlS7cdbxhiby3rQsj7DMib+3WGzVeBaVdLDp8+BPffLn7fZPBj2L9m4Cxlss5H/A/sgaAdlZQBCTNvDvERVdV6MJQ6nrkEih/DErsqQDkiSl/I6IZWSElcx8PNU1a0f0FSerClYecAkIZ3AqGCeHViOepimzHDhfzwlwH2rlLh+N7YHCEPj0XB9TbtD+r/1KAtyBdkfI4TYj+rqljnyb91thjEuBqMCPuDJBz/+TB9YFjLmLrhkDMyT435tM5qD/jburceTejf4+nVv8ULHe/LkhYt8EN0=
+    - secure: SA+xtCT5p/Lwk0VT7rjH0BLNiYfRbmd3E4zrKSIn0ZCi/QyEHb39KhlZm6qfTcrT4G5qnOuKlyybE358yoVlicu+K00OWwTKTuOeRS8FkB235j2gQbjp+hDFkEkQZXcqRr8QCYsY4QGq3WmMr2+2GAuHkXh/3hx/gkEKU0ZaOBg3QcUCzvkMNHQxT8NlgMnBP1Uu7TjfxZS2Q0Gl1y2ZY/bYhQhG4OwsbrvbaCsFzWW9WUO9xZPgqVfl/WZZLJ8kaaoTRo8kPEydymdh8KNPVEy5GmteLy8aUeYMzl46Ap0IcFK4lA5JOQfF1xxkl4IVW/CG5ncUwQOMzC3FDIfGvMVV3FKdDJLrdUYxgU+rSA4dQF6gIWo3ftwRZVBMDHrSIQyqD7+lsTbXzATIpz7V5Ko0HPadMGA5dEWpUtYn6PnjKsMWYoa57kEARY9Tya8054M5rGdyih6IjCfm5t7uSvMk3sdiFd8UbeftlxaUoDQHPH57NTyLRrbLWgi4qJEj4nlM9rYPBqe0N4lkQJeYqQEyRTKhInmMqm/vpL5ZS9S75hOuNz19woES3rtIXpItjA4q6xWqdJQshXj4U7q9rFtAKaWlF+GHnQMNK4ObBvn5R6c/KevpN3Du2DeGrZfN1tR3jp8zHL78CQzfgT0NVLx9S7liDjXRl0uGxrs/V1k=
+
 
 before_install:
-  - cd $DIR
+- cd $DIR
+- pip install --user awscli
+
+script:
+- npm test
+- npm run validate-template
 
 stages:
-  - test
-  - name: deploy to staging
-    # if: branch = master
+- test
+- name: deploy to staging
+  if: branch = master
 
 jobs:
   include:
-    - stage: deploy to staging
-      script: echo "TODO Deploy code to S3"
-      env: DIR='./frontend'
-    - stage: deploy to staging
-      script: echo "TODO Deploy code to CloudFormation"
-      env: DIR='./api'
-
+  - stage: deploy to staging
+    env:
+    - DIR='./frontend'
+    - STAGE='stg'
+    script:
+    - npm run build
+    - npm run deploy
+    - npm run invalidate-cache
+  - stage: deploy to staging
+    env:
+    - DIR='./api'
+    - STAGE='stg'
+    script: echo "TODO Deploy code to CloudFormation"

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,8 @@
     "build": "NODE_ENV=${NODE_ENV:-production} webpack",
     "package": "sam package --template-file template.yaml --s3-bucket $npm_package_name-${STAGE:-dev} --output-template-file template.packaged.yaml",
     "deploy": "sam deploy --template-file template.packaged.yaml --stack-name $npm_package_name-${STAGE:-dev} --capabilities CAPABILITY_IAM --region us-west-2 --parameter-overrides Stage=${STAGE:-dev}",
-    "clean": "rm -rf -v dist/*"
+    "clean": "rm -rf -v dist/*",
+    "validate-template": "aws cloudformation validate-template --template-body file://template.yaml"
   },
   "repository": {},
   "author": "",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,56 @@
 # Cadasta Esri Admin
 
-## Commands
-
-- `start`
-- `build`
-- `test`
+This is the frontend to Cadasta's custom Esri ArcGIS Enterprise administration application.
 
 ## Development
+
+### Project setup
+
+In `frontend/`, run `npm install` to install required dependencies.
+
+### Development Server
+
+Run `npm start` to start development server. This will watch the `frontend/src` directory for changes, rebuilding the application and reloading the browser when necessary.
+
+### Testing
+
+Run `npm test` to start [Jest](http://jestjs.io/) test runner. This will watch the `frontend/src` directory for changes, running tests when necessary.
+
+Run `npm test -- --coverage` to generate a coverage report.
+
+Run `npm run validate-template` to validate CloudFormation `template.yaml` (requires available AWS credentials with appropriate permissions: `cloudformation:CreateChangeSet`, `cloudformation:ValidateTemplate`, `cloudformation:GetTemplateSummary`, `cloudformation:DescribeStacks`).
+
+### Deployment
+
+Steps to deployment are as follows:
+
+1. `npm run build`, generate static website assets (located in `dist/`) that can be served as the frontend application.
+2. *[optional]* `npm run deploy-stack`, (utilizes [`STAGE` environment variable](#stages)), deploy AWS infrastructure (via CloudFormation) for hosting frontend application. Only needs to be run:
+    * Once per-stage per-lifetime of project.
+    * When the CloudFormation template (`template.yaml`) is updated.
+3. `npm run deploy`, (utilizes [`STAGE` environment variable](#stages), requires [jq](https://stedolan.github.io/jq/)), deploys static website assets (from `dist/`) to S3 bucket.
+4. `npm run invalidate-cache`, (utilizes [`STAGE` environment variable](#stages), requires [jq](https://stedolan.github.io/jq/)), instruct CloudFront to clear its cache for the application, serving updated files on subsequent requests.
+
+#### Stages
+
+Deployment of this project looks to the `STAGE` environment variable to determine to which environment the deployment instruction applies. Valid stages are:
+
+* `dev` (default if no `STAGE` environment variable is declared)
+* `stg`
+* `prod`
+
+
+#### Infrastructure Architecture
+
+The infrastructure for the frontend (e.g. S3 Bucket, CloudFronts distribution) is managed via the included CloudFormation template (`template.yaml`). Components:
+
+* Route53 - Manages URL for application
+* CloudFront - Manages SSL, provides caching-layer on top of S3 resources, ensures all requests are directed to `/index.html`
+* S3 - Hosts static assets.
+
+### CI
+
+Travis automatically tests all PRs via `npm test` and `npm run validate-template`. Code merged into `master` is already built and deployed to the `stg` environment.
 
 ### Recommended Reading
 
@@ -28,6 +72,7 @@
 - Filenames for files exporting a Container or Component should be uppercased. Any supporting file (e.g. `css` or `.spec.ts` files should also be uppercase). Filenames for files that do not export a Container or Component should be lowercased.
 - Test files should have filenames that mirror the files they are testing, but end with `.spec.ts`
 
-### Dev Tools
+### Recommended Supported Developer Tools
 
+* [React Developer Tools](https://github.com/facebook/react-devtools)
 * [Redux DevTools Extension](http://extension.remotedev.io/)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,14 @@
     "start": "react-scripts-ts start",
     "build": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
-    "eject": "react-scripts-ts eject"
+    "eject": "react-scripts-ts eject",
+    "deploy": "aws s3 sync build/ s3://$(npm run --silent describe-stack:website-bucket)",
+    "deploy-stack": "aws cloudformation deploy --template-file template.yaml --stack-name $npm_package_name-${STAGE:-dev} --parameter-overrides Stage=${STAGE:-dev} --no-fail-on-empty-changeset",
+    "validate-template": "aws cloudformation validate-template --template-body file://template.yaml",
+    "invalidate-cache": "aws cloudfront create-invalidation --distribution-id $(npm run --silent describe-stack:distribution-id) --paths '/*'",
+    "describe-stack": "aws cloudformation describe-stacks --stack-name $npm_package_name-${STAGE:-dev}",
+    "describe-stack:distribution-id": "npm run --silent describe-stack | jq --raw-output '.Stacks[0].Outputs[] | select(.OutputKey == \"DistributionId\") | .OutputValue'",
+    "describe-stack:website-bucket": "npm run --silent describe-stack | jq --raw-output '.Stacks[0].Outputs[] | select(.OutputKey == \"WebsiteBucket\") | .OutputValue'"
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",

--- a/frontend/template.yaml
+++ b/frontend/template.yaml
@@ -1,0 +1,160 @@
+# Based on https://github.com/rogerchi/cloudformation-s3-website-ssl-with-redirect/blob/master/cloudformation-s3-website-ssl-with-redirect.yaml
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Frontend Deployment Configuration for Single Page Applications
+
+Parameters:
+  DomainName:
+    Description: Domain name for your website (e.g. cadasta.org)
+    Type: String
+    Default: cadasta.org
+  Stage:
+    Description: Stage of deployment. Enter dev, stg, or prod. Default is dev.
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - stg
+      - prod
+  SSLCert:
+    Description: ACM SSL Certificate
+    Type: String
+    Default: arn:aws:acm:us-east-1:910612869735:certificate/b6f4b44f-8d2a-4183-adab-7819d26e21e1 # *.cadasta.org
+
+Mappings:
+  StageDetails:
+    dev:
+      Subdomain: admin-dev
+    stg:
+      Subdomain: admin-stg
+    prod:
+      Subdomain: admin
+  RegionMap:
+    us-east-1:
+      WebsiteEndpoint: s3-website-us-east-1.amazonaws.com
+    us-west-1:
+      WebsiteEndpoint: s3-website-us-west-1.amazonaws.com
+    us-west-2:
+      WebsiteEndpoint: s3-website-us-west-2.amazonaws.com
+    eu-west-1:
+      WebsiteEndpoint: s3-website-eu-west-1.amazonaws.com
+    ap-southeast-1:
+      WebsiteEndpoint: s3-website-ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      WebsiteEndpoint: s3-website-ap-southeast-2.amazonaws.com
+    ap-northeast-1:
+      WebsiteEndpoint: s3-website-ap-northeast-1.amazonaws.com
+    sa-east-1:
+      WebsiteEndpoint: s3-website-sa-east-1.amazonaws.com
+
+Resources:
+  WebsiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub
+        - cadasta-arcgis-admin-${Stage}
+        - Stage: !Ref Stage
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument: index.html
+
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      PolicyDocument:
+        Id: S3WebsiteServingPolicy
+        Version: 2012-10-17
+        Statement:
+          - Sid: PublicReadForGetBucketObjects
+            Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub arn:aws:s3:::${WebsiteBucket}/*
+      Bucket: !Ref WebsiteBucket
+
+  LogBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${WebsiteBucket}-logs
+      LifecycleConfiguration:
+        Rules:
+        - Id: DeleteIn3Months
+          Status: Enabled
+          ExpirationInDays: '90'
+
+  CloudFront:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: 'true'
+        Origins:
+        - DomainName: !Sub # Get website assets from S3 bucket
+          - ${WebsiteBucket}.${S3WebEndpoint}
+          - WebsiteBucket: !Ref WebsiteBucket
+            S3WebEndpoint: !FindInMap [RegionMap, !Ref "AWS::Region", WebsiteEndpoint]
+          Id: !Sub
+            - ${Subdomain}-${DomainName}
+            - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
+          CustomOriginConfig:
+            OriginProtocolPolicy: http-only
+        Comment: !Sub
+          - Distribution for ${URL}
+          - URL: !Sub
+            - ${Subdomain}.${DomainName}
+            - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
+        HttpVersion: http2
+        Logging:
+          IncludeCookies: 'false'
+          Bucket: !Sub ${LogBucket}.s3.amazonaws.com
+        Aliases: # Allowed URLs for distribution
+        - !Sub
+          - ${Subdomain}.${DomainName}
+          - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
+        DefaultCacheBehavior:
+          AllowedMethods: # TODO: Should these all be allowed? Why not just GET & HEAD & OPTIONS
+          - GET
+          - HEAD
+          - OPTIONS
+          TargetOriginId: !Sub
+            - ${Subdomain}-${DomainName}
+            - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
+          Compress: True
+          MinTTL: 300
+          DefaultTTL: 300
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: none
+          ViewerProtocolPolicy: redirect-to-https
+        PriceClass: PriceClass_100
+        ViewerCertificate:
+          AcmCertificateArn: !Ref SSLCert
+          SslSupportMethod: sni-only
+        CustomErrorResponses:
+        # Ensure that not-found S3 keys instead return 'index.html' with a 200-response, allowing SPA to handle logic
+        - ErrorCode: 404
+          ResponseCode: 200
+          ResponsePagePath: /index.html
+
+  Route53Subdomain:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      HostedZoneName: !Sub ${DomainName}.
+      Comment: Zone apex alias.
+      RecordSets:
+      - Name: !Sub
+          - ${Subdomain}.${DomainName}
+          - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
+        Type: A
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # hardcoded CloudFront ID
+          DNSName: !GetAtt CloudFront.DomainName
+
+Outputs:
+  WebsiteURL:
+    Value: !GetAtt WebsiteBucket.WebsiteURL
+    Description: URL for website hosted on S3
+  DistributionId:
+    Value: !Ref CloudFront
+  WebsiteBucket:
+    Value: !Ref WebsiteBucket

--- a/frontend/template.yaml
+++ b/frontend/template.yaml
@@ -111,7 +111,7 @@ Resources:
           - ${Subdomain}.${DomainName}
           - Subdomain: !FindInMap [ StageDetails, !Ref Stage, Subdomain]
         DefaultCacheBehavior:
-          AllowedMethods: # TODO: Should these all be allowed? Why not just GET & HEAD & OPTIONS
+          AllowedMethods:
           - GET
           - HEAD
           - OPTIONS


### PR DESCRIPTION
Added CI tooling for automatic testing and deployment of the application.  The application is currently set to be deployed from https://admin-dev.cadasta.org / https://admin-stg.cadasta.org / https://admin.cadasta.org (not yet deployed). The [ArcGIS Enterprise Oauth Application](https://maps.cadasta.org/arcgis/home/item.html?id=cc470cbf76664991944169b36ee7f5d0#settings) was updated to allow redirects to `https://*.cadasta.org`.

I am going to purposefully not describe this too much, as the `README.md` should cover it all.  Let me know if anything is unclear.