### PR TITLE
Separate build dir for output files, allowing for smaller Lambda function uploads

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8158,16 +8158,6 @@
         }
       }
     },
-    "read-yaml": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.1.0.tgz",
-      "integrity": "sha1-DSc6wMlb6SIw3A1MTE9biWCjNtY=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.8.2"
-      }
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -10933,6 +10923,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yaml-cfn": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/yaml-cfn/-/yaml-cfn-0.2.0.tgz",
+      "integrity": "sha1-SvktOUZmAbzQbHB1ABVXoNuQgyM=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.10.0"
+      }
     },
     "yargs": {
       "version": "11.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -28,7 +28,6 @@
     "@types/uuid": "^3.4.3",
     "aws-sdk": "^2.234.1",
     "jest": "^23.1.0",
-    "read-yaml": "^1.1.0",
     "ts-jest": "^22.4.6",
     "ts-loader": "^4.2.0",
     "ts-node": "^6.0.3",
@@ -38,7 +37,8 @@
     "typescript": "^2.8.3",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.7.0",
-    "webpack-cli": "^2.1.3"
+    "webpack-cli": "^2.1.3",
+    "yaml-cfn": "^0.2.0"
   },
   "jest": {
     "transform": {

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -23,8 +23,7 @@ Resources:
   AdminApi:
     Type: AWS::Serverless::Api
     Properties:
-      StageName:
-        Fn::Sub: ${Stage}
+      StageName: !Sub ${Stage}
 
       DefinitionBody: # https://swagger.io/specification/
         swagger: 2.0
@@ -46,8 +45,7 @@ Resources:
               x-amazon-apigateway-integration:
                 httpMethod: POST
                 type: aws_proxy
-                uri:
-                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Hello.Arn}/invocations
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Hello.Arn}/invocations
               responses: {}
               security:
                 - CustomAuthorizer: []
@@ -71,8 +69,7 @@ Resources:
               x-amazon-apigateway-integration:
                 httpMethod: POST
                 type: aws_proxy
-                uri:
-                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProjectsCreate.Arn}/invocations
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProjectsCreate.Arn}/invocations
               responses: {}
               security:
                 - CustomAuthorizer: []
@@ -108,10 +105,8 @@ Resources:
             x-amazon-apigateway-authtype: custom
             x-amazon-apigateway-authorizer:
               type: token
-              authorizerUri:
-                Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ArcGisAuthorizer.Arn}/invocations
-              authorizerCredentials:
-                Fn::Sub: ${ApiGatewayAuthorizerRole.Arn}
+              authorizerUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ArcGisAuthorizer.Arn}/invocations
+              authorizerCredentials: !Sub ${ApiGatewayAuthorizerRole.Arn}
               authorizerResultTtlInSeconds: 600  # How long to cache the authorization
 
   # Functions
@@ -121,7 +116,7 @@ Resources:
     Properties:
       Handler: hello.default
       Runtime: nodejs8.10
-      CodeUri: ./dist
+      CodeUri: ./dist/hello
       Timeout: 5
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -139,7 +134,7 @@ Resources:
     Properties:
       Handler: projects/create.default
       Runtime: nodejs8.10
-      CodeUri: ./dist
+      CodeUri: ./dist/projects
       Timeout: 5
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -162,7 +157,7 @@ Resources:
     Properties:
       Handler: authorizer.default
       Runtime: nodejs8.10
-      CodeUri: ./dist
+      CodeUri: ./dist/authorizer/bar
       Timeout: 5
       Environment:
         Variables:
@@ -208,12 +203,10 @@ Resources:
                 Action:
                   - lambda:InvokeAsync
                   - lambda:InvokeFunction
-                Resource:
-                  Fn::Sub: ${ArcGisAuthorizer.Arn}
+                Resource: !Sub ${ArcGisAuthorizer.Arn}
 
 Outputs:
   ApiURL:
     Description: API endpoint URL for Prod environment
-    Value:
-      Fn::Sub: https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/hello
+    Value: !Sub https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/hello
 


### PR DESCRIPTION
Currently, when `sam` uploads Lambda functions, it uploads the code for all of our functions:

<img width="802" alt="screen shot 2018-07-04 at 2 44 04 pm" src="https://user-images.githubusercontent.com/897290/42294257-a141b1ce-7f9c-11e8-87a5-1b9bb2d60d2e.png">

This is a small fixup to ensure that when `sam` uploads our functions, it only uploads the packaged code needed for each function.