### PR TITLE
List Project Front-End

### DIFF
--- a/frontend/src/app/App.css
+++ b/frontend/src/app/App.css
@@ -73,3 +73,10 @@ h6 {
   margin-top: .3rem;
   margin-left: -1.25rem;
 }
+
+.breadcrumb {
+  background-color: transparent;
+  padding-left: 0;
+  margin-top: -36px;
+  font-size: 12px;
+}

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -6,12 +6,14 @@ import { Guard, guards } from "../auth/guards";
 import SignIn from "../auth/SignIn";
 import Home from "../home/Home";
 import CreateProject from "../projects/Create";
+import ListProjects from "../projects/List";
 import NoMatch from "./NoMatch";
 
 export const urls: { [key: string]: string } = {
   Home: "/",
   SignIn: "/auth/sign-in",
   CreateProject: "/projects/create",
+  ListProjects: "/projects/list",
   NoMatch: "nomatch"
 };
 
@@ -47,6 +49,12 @@ const routeConfig: RouteDeclaration[] = [
   {
     path: urls.CreateProject,
     component: CreateProject,
+    exact: true,
+    checks: [guards.isLoggedIn]
+  },
+  {
+    path: urls.ListProjects,
+    component: ListProjects,
     exact: true,
     checks: [guards.isLoggedIn]
   },

--- a/frontend/src/home/Home.tsx
+++ b/frontend/src/home/Home.tsx
@@ -7,13 +7,16 @@ import { PageHeader } from "../shared/styled-components/PageHeader";
 interface Props extends React.HTMLAttributes<HTMLElement> {}
 const Home: React.SFC<Props> = ({ className = "" }) => (
   <div>
-    <PageHeader>Dashboard</PageHeader>
+    <PageHeader>Home</PageHeader>
     <ul>
       <li>
         <Link to={urls.SignIn}>Sign In</Link>
       </li>
       <li>
         <Link to={urls.CreateProject}>Create Project</Link>
+      </li>
+      <li>
+        <Link to={urls.ListProjects}>View Projects</Link>
       </li>
     </ul>
   </div>

--- a/frontend/src/projects/Create.tsx
+++ b/frontend/src/projects/Create.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { Checkbox, CheckboxGroup } from "react-checkbox-group";
 import { connect, DispatchProp } from "react-redux";
-import { RouteProps } from "react-router-dom";
-import { Button, Col, Form, FormGroup, FormText, Input, Label } from "reactstrap";
+import { Link, RouteProps } from "react-router-dom";
+import { Breadcrumb, BreadcrumbItem, Button, Col, Form, FormGroup, FormText, Input, Label } from "reactstrap";
 
 import { StoreState } from "../app/reducers";
+import { urls } from "../app/routes";
 import { ADMIN_API_PROJECT_URL } from "../config";
 import { PageHeader } from "../shared/styled-components/PageHeader";
 
@@ -34,6 +35,11 @@ class Create extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <PageHeader>Create Project</PageHeader>
+        <Breadcrumb>
+          <BreadcrumbItem><Link to={urls.Home}>Home</Link></BreadcrumbItem>
+          <BreadcrumbItem><Link to={urls.ListProjects}>Projects</Link></BreadcrumbItem>
+          <BreadcrumbItem active>Create new project</BreadcrumbItem>
+        </Breadcrumb>
         <Form onSubmit={this.createProject}>
           <FormGroup row>
             <Label for="projectName" sm={3}>Project name</Label>

--- a/frontend/src/projects/List.tsx
+++ b/frontend/src/projects/List.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { Breadcrumb, BreadcrumbItem, Button, Table } from "reactstrap";
+
+import { urls } from "../app/routes";
+import { PageHeader } from "../shared/styled-components/PageHeader";
+
+interface Props extends React.HTMLAttributes<HTMLElement> {}
+
+const ProjectList: React.SFC<Props> = ({ className = "" }) => (
+  <div>
+    <PageHeader>Projects</PageHeader>
+    <Breadcrumb>
+      <BreadcrumbItem><Link to={urls.Home}>Home</Link></BreadcrumbItem>
+      <BreadcrumbItem active>Projects</BreadcrumbItem>
+    </Breadcrumb>
+    <Button color="primary" size="sm" className="mb-3" tag={Link} to={urls.CreateProject}>Create New</Button>
+    <Table hover>
+        <thead>
+          <tr>
+            <th>Project Name</th>
+            <th>Owner</th>
+            <th>Created</th>
+            <th>Last Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">A Longer Example of a Sample Project Name Longer</th>
+            <td>ownername</td>
+            <td>Jun 11, 2018</td>
+            <td>Jun 11, 2018</td>
+          </tr>
+          <tr>
+            <th scope="row">Sample Project Name</th>
+            <td>ownername</td>
+            <td>Jun 11, 2018</td>
+            <td>Jun 11, 2018</td>
+          </tr>
+          <tr>
+            <th scope="row">Sample Project Name</th>
+            <td>ownername</td>
+            <td>Jun 11, 2018</td>
+            <td>Jun 11, 2018</td>
+          </tr>
+        </tbody>
+      </Table>
+
+  </div>
+);
+export default ProjectList;


### PR DESCRIPTION
**Included in this PR:**

- Added new **List.tsx** page to projects folder to view all projects. List.tsx contains a simple table that lists projects alphabetically by project name. This is ready to be connected to the api fields.
- Added "create new" button (link) to top of view all projects page. Eventually this should be better folded into the page design. 
- Added breadcrumbs below page header since I think this will help as a temporary fix to keep order while we develop more pages. Eventually this should be better folded into the page design.
- Renamed dashboard back to home to be logical link in breadcrumb.

<img width="904" alt="screenshot 2018-07-24 14 22 53" src="https://user-images.githubusercontent.com/1119621/43161493-e299982e-8f4d-11e8-9b07-11f0f59a5cf0.png">


