### PR TITLE
Only deploy to staging if pushed branch to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,19 @@ stages:
 - test
 - lint
 - name: deploy to staging
-  if: branch = master
+  if: branch = master AND type = push
 
 jobs:
   include:
   - stage: lint
     env:
     - DIR='./frontend'
-    script: 
+    script:
     - npm run lint
   - stage: lint
     env:
     - DIR='./api'
-    script: 
+    script:
     - npm run lint
   - stage: deploy to staging
     env:


### PR DESCRIPTION
If you look at other PR builds (e.g [build #126](https://travis-ci.org/Cadasta/cadasta-arcgis-admin/jobs/413787422)), you'll see that it is deploying the code to staging. This is a mistake and security risk.  Instead, we should only deploy to staging when we push to `master`.