### PR TITLE
If no action is received, return current state, not default state

### DIFF
--- a/frontend/src/projects/projectsReducer.ts
+++ b/frontend/src/projects/projectsReducer.ts
@@ -74,7 +74,7 @@ export const projectsReducer = (state: ProjectsState = defaultState, action: Pro
       };
 
     default:
-      return defaultState;
+      return state;
   }
 };
 


### PR DESCRIPTION
The `projectsReducer` is incorrectly set up to return the `defaultState` rather than the current `state` when an unrelated action passes through it.  This means that if a non-project action is dispatched, the project state will clear back to its default.